### PR TITLE
add cron based build triggers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ pipeline {
     disableConcurrentBuilds()
   }
 
+  triggers { cron('@hourly') }
+
   stages {
     stage('Build Docker image') {
       agent any


### PR DESCRIPTION
use schedules to rebuild this image to ensure we have the latest stable nginx version in our base image

https://www.jenkins.io/doc/book/pipeline/syntax/#triggers