### PR TITLE
switch to weekly cron rebuilds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     disableConcurrentBuilds()
   }
 
-  triggers { cron('@hourly') }
+  triggers { cron('@weekly') }
 
   stages {
     stage('Build Docker image') {


### PR DESCRIPTION
builds on #4 and switches the timer from `hourly` to `weekly` so any new stable 1.20 nginx base image updates are automatically built into our custom base image for use in normal builds like static proxy nginx 