### PR TITLE
Update nginx to version 1.29

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  NGINX_VERSION: '1.20'
+  NGINX_VERSION: '1.29'
 
 jobs:
   build_and_push_image:


### PR DESCRIPTION
When this PR merges, an action will run that will build and push the new 1.29 image with `1.29` and `latest` tags to the GHCR. 

Existing images on Dockerhub will remain unchanged, including the latest tag (still 1.20). All webhooks have been deactivated.

Individual apps that use this image in their stacks (static, panoptes, caesar, talk) will be individually migrated from Dockerhub to GHCR.

