### PR TITLE
Create list of Azure FD IP directives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,18 @@
 ARG VERSION=invalid
 FROM nginx:$VERSION
 
+# Required to parse Azure JSON
+RUN apt-get update && apt-get install -y jq && apt-get clean
+
 RUN mkdir -p /etc/nginx-sites
 RUN echo "listen 80;" > /etc/nginx/listen.default.conf
 # This image doesn't actually configure SSL but the following symlink is for backwards compatibility
 RUN ln -s /etc/nginx/listen.default.conf /etc/nginx/ssl.default.conf
 
 COPY nginx.conf /etc/nginx/nginx.conf
+
+# Generate a list of Azure Front Door IPs and create an
+# optionally includable set of set_real_ip_from directives
+COPY generate-azure-directives.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/generate-azure-directives.sh && /usr/local/bin/generate-azure-directives.sh
+RUN rm -f /usr/local/bin/generate-azure-directives.sh

--- a/generate-azure-directives.sh
+++ b/generate-azure-directives.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+AZURE_IPS_URL="https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519"
+ACTUAL_URL=$(curl -sL "$AZURE_IPS_URL" | grep -Eo 'https://download\.microsoft\.com/download/[^"]*\.json' | head -1)
+
+if [ -z "$ACTUAL_URL" ]; then
+    echo "Error: Could not find Azure IP ranges download URL"
+    exit 1
+fi
+
+curl -s "$ACTUAL_URL" | jq -r '
+.values[] |
+select(.name | test("AzureFrontDoor"; "i")) |
+.properties.addressPrefixes[]' | sort -u > azure_frontdoor_ips.txt
+
+IP_COUNT=$(wc -l < ./azure_frontdoor_ips.txt)
+echo "Retrieved $IP_COUNT Azure Front Door IP ranges"
+
+while read ip; do
+    echo "set_real_ip_from $ip;"
+done < azure_frontdoor_ips.txt > /etc/nginx/nginx-azure-ips.conf


### PR DESCRIPTION
Adds a script that downloads and parses a list of Azure Front Door IPs. This list is transformed into `set_real_ip_from` directives and stored in `/etc/nginx` as an includable conf file. 

Because of how this base image is used differently across apps, this conf file is intentionally not included in this repo's nginx.conf. This way, it can be included both by the static proxy, sidecar nginx containers in front of apps, etc. where appropriate.