### PR TITLE
Remove real_ip_recursive directive

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -15,9 +15,11 @@ http {
     types_hash_max_size 2048;
     client_max_body_size 20m;
 
-    log_format  main  '$remote_addr $host $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" $upstream_cache_status' ;
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    '"$http_x_real_ip"';
+
     access_log /dev/stdout main;
     error_log /dev/stderr;
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,11 +27,15 @@ http {
     gzip_disable "msie6";
     gzip_proxied any;
 
-    real_ip_header X-Forwarded-For;
-    real_ip_recursive on;
+    # Include the list of set_real_ip_from directives above real_ip_header & realip_recursive
+    include /etc/nginx-sites/*.conf;
+
     set_real_ip_from 10.0.0.0/8;
     set_real_ip_from 172.30.0.0/16;
 
     include /etc/nginx/mime.types;
-    include /etc/nginx-sites/*.conf;
+
+    # Do this last to ensure proper filtering
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,15 +27,9 @@ http {
     gzip_disable "msie6";
     gzip_proxied any;
 
-    # Include the list of set_real_ip_from directives above real_ip_header & realip_recursive
-    include /etc/nginx-sites/*.conf;
-
     set_real_ip_from 10.0.0.0/8;
     set_real_ip_from 172.30.0.0/16;
 
     include /etc/nginx/mime.types;
-
-    # Do this last to ensure proper filtering
-    real_ip_header X-Forwarded-For;
-    real_ip_recursive on;
+    include /etc/nginx-sites/*.conf;
 }


### PR DESCRIPTION
All of the relevant set_real_ip_from directives must be set prior to setting real_ip_recursive to on. Nginx needs to know what the IPs to filter are before it can remove them.

So this removes real_ip_recursive and real_ip_header and makes them the responsibility of the nginx instance that builds with this image as a base. The http-frontend repo already starts with its own nginx.conf as a base and has these directives in the correct order. Panoptes will need to have these directives added to its sidecar pod configuration after the spot where the AFD IPs are being included.

I also modified the log_format to include the $http_x_forwarded_for and $http_x_real_ip headers for better debugging.